### PR TITLE
Update example to match test/basic-express.tap.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ var app = express();
 app.use(clsify(ns));
 
 app.get('/users', function (req, res, next) {
-  // clse.getNamespace('namespace').get('whatever') will work here now.
+  // ns.get('whatever') will work here now.
 });
 ```


### PR DESCRIPTION
There was a typo (`clse` vs. `cls`) and reading the test made it clear that `ns` already referred to the namespace so it seemed like that was a good way to illustrate what was happening.
