### PR TITLE
Updating dependencies for CLS 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "url": "https://github.com/othiym23/cls-middleware/issues"
   },
   "dependencies": {
-    "continuation-local-storage": "~2"
+    "continuation-local-storage": "~3"
   },
   "devDependencies": {
-    "continuation-local-storage": "~2",
+    "continuation-local-storage": "~3",
     "express": "~3.4.3",
     "tap": "~0.4.4",
     "request": "~2.27.0"


### PR DESCRIPTION
Not sure how you want to handle the cls-middleware version for this change, so I've left that alone.
