### PR TITLE
made example in readme runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Connect / Restify middleware for CLS
 
-Dirt-simple middleware for Connect and Restify handlers into a
-continuation-local storage context.
+Dirt-simple middleware for Connect and Restify handlers that sets up
+a continuation-local storage context per request.
 
 Example `app.js`:
 
@@ -11,25 +11,29 @@ var express = require('express');
 var clsify  = require('cls-middleware');
 var route   = require('./route.js');
 
-var ns = cls.createNamespace('namespace');
+// you can use any namespace name as long as you use the same for set/get
+var ns = cls.createNamespace('requestScope');
+var requestCounter = 0;
 
 var app = express();
+// let the middleware set up the continuation-local storage context
 app.use(clsify(ns));
-
-ns.set('whatever', 'a value');
+app.use(function (req, res, next) {
+  // put something in the namespace, a requestId in this case
+  ns.set('reqId', ++requestCounter);
+  next();
+});
 
 app.get('/users', route);
 ```
 
-with `./route.js`:
+and `./route.js`:
 
 ```js
 var cls = require('continuation-local-storage');
 
 module.exports = function (req, res, next) {
-  // pulling from the namespace, and set up per request
-  res.send({value : cls.getNameSpace('namespace').get('whatever')});
-
-  next();
+  // pulling from the namespace which is set up per request
+  res.send({value : cls.getNamespace('requestScope').get('reqId')});
 };
 ```


### PR DESCRIPTION
The most important fix was getNameSpace => getNamespace but also the removal of the superfluous "next()" in the route (necessary for restify but makes express crash with "Error: Can't set headers after they are sent".

The example also crashed on the ns.set with "Error: No context available. ns.run() or ns.bind() must be called first." so I introduced a naive requestId middleware to set something in the request call chain.
